### PR TITLE
use start time instead of air date as fallback 2

### DIFF
--- a/mythEx.py
+++ b/mythEx.py
@@ -10,6 +10,15 @@ import cgi
 import sys
 from MythTV.tmdb3 import searchMovie
 from MythTV.tmdb3 import set_key
+import calendar
+from datetime import datetime, timedelta
+
+def utc_to_local(utc_dt):
+    # get integer timestamp to avoid precision lost
+    timestamp = calendar.timegm(utc_dt.timetuple())
+    local_dt = datetime.fromtimestamp(timestamp)
+    assert utc_dt.resolution >= timedelta(microseconds=1)
+    return local_dt.replace(microsecond=utc_dt.microsecond)
 
 if config.moviedb_enabled:
     set_key(config.moviedb_api_key)
@@ -23,16 +32,16 @@ if platform.system() == "Windows":
 else:
     separator = "/"
 
-if os.path.isfile('library') or os.path.islink('library'):
-    library = open('library', 'r')
-    lib = re.split(",", library.read())
-    library.close()
-else:
-    lib = ""
+# library doesn't seem to do anything - removed
+#if os.path.isfile('library') or os.path.islink('library'):
+#    library = open('library', 'r')
+#    lib = re.split(",", library.read())
+#    library.close()
+#else:
+#    lib = ""
 
 url = "http://" + config.host_url + ":" + config.host_port
-print "Beginning symlinking."
-print "Looking up from MythTV: " + url + '/Dvr/GetRecordedList'
+print "[INFO] Looking up from MythTV: " + url + '/Dvr/GetRecordedList'
 
 tree = ET.parse(urllib.urlopen(url + '/Dvr/GetRecordedList'))
 root = tree.getroot()
@@ -47,46 +56,63 @@ for program in root.iter('Program'):
     ep_file_name = program.find('FileName').text
     ep_id = program.find('ProgramId').text
     ep_airdate = program.find('Airdate').text
+    ep_temp = program.find('StartTime').text
+    ep_start_time = utc_to_local(datetime.strptime(ep_temp, '%Y-%m-%dT%H:%M:%SZ'))
+    # parse start time for file-system safe name
+    ep_start_time = datetime.strftime(ep_start_time, '%Y-%m-%d %H%M')
 
     # parse show name for file-system safe name
     title = re.sub('[\[\]/\\;><&*%=+@!#^()|?]', '_', title)
 
     episode_name = title + " - S" + ep_season + "E" + ep_num
+    print "[INFO] Processing " + episode_name + " ..."
 
     # Skip previously finished files
-    if len(lib) > 0:
-        if ep_id in lib:
-            print "Matched program ID, skipping " + episode_name
-            continue
-        else:
-            lib.append(ep_id)
+#    if len(lib) > 0:
+#        if ep_id in lib and (ep_season != '00' or ep_num != '00'):
+#            print "[WARN] Matched program ID" + ep_id + ", skipping " + episode_name
+#            continue
+#        else:
+#	    print "[INFO] Adding " + episode_name + " to library"
+#            lib.append(ep_id)
 
     # Handle specials, movies, etc.
     if ep_season == '00' and ep_num == '00':
         #Fallback 1: Check TheMovieDB
+	print "[WARN] no season or episode info - trying fallbacks"
         moviedb_successful = False
         moviedb_run = False
         if (config.moviedb_enabled):
-            print "Querying TheMovieDB for " + title
+            print "[INFO] (fallback 1) Querying TheMovieDB for " + title
             res = searchMovie(title)
             if (len(res) is 0):
                 moviedb_successful = False
-                print "Could not look up from TheMovieDB"
+                print "[WARN] " + episode_name + "not found in TheMovieDB"
             else: 
+		print "[INFO] Successfully looked up in MovieDB"
                 moviedb_successful = True
                 print (res[0].title)
                 title = re.sub('[\[\]/\\;><&*%=+@!#^()|?]', '_', res[0].title)
                 episode_name = title
-        #Fallback 2: Air date
-        if (ep_airdate is not None and moviedb_run is True and
-                moviedb_successful is False):
-            episode_name = title + " - " + ep_airdate
+ 
+	#Fallback 2: start time 
+        if (ep_start_time is not None): 
+	    if (moviedb_run is False or (moviedb_run is True and
+                moviedb_successful is False)):
+	        print "[INFO] (fallback 2) using start time"
+                episode_name = title + " - " + ep_start_time
+	        print "[INFO] Changed to " + episode_name
         else:
-            continue
+	    print "[WARN] no start time available"
+
+    else:
+	print "[INFO] have season and episode." 
 
     # Symlink path
+    print "[INFO] symlink processing.."
     link_path = (config.plex_tv_directory +
                  title + separator + episode_name + ep_file_extension)
+    #print "[INFO] link path is " + link_path
 
     # Watch for oprhaned recordings!
     source_dir = None
@@ -97,26 +123,26 @@ for program in root.iter('Program'):
             break
 
     if source_dir is None:
-        print ("Cannot create symlink for "
+        print ("[ERROR] Cannot create symlink for "
                + episode_name + ", no valid source directory.  Skipping.")
         continue
 
     if os.path.exists(link_path) or os.path.islink(link_path):
-        print "Symlink " + link_path + " already exists.  Skipping."
+        print "[WARN] Symlink " + link_path + " already exists.  Skipping."
         continue
 
     if not os.path.exists(config.plex_tv_directory + title):
-        print "Show folder does not exist, creating."
+        print "[INFO] Show folder does not exist, creating."
         os.makedirs(config.plex_tv_directory + title)
 
-    print "Linking " + source_path + " ==> " + link_path
+    print "[INFO] Linking " + source_path + " ==> " + link_path
     os.symlink(source_path, link_path)
 
 # Save the list of file IDs
-outstring = ""
-for item in lib:
-    outstring += item + ","
-
-library = open('library', 'w')
-library.write(outstring)
-library.close()
+#outstring = ""
+#for item in lib:
+#    outstring += item + ","
+#
+#library = open('library', 'w')
+#library.write(outstring)
+#library.close()


### PR DESCRIPTION
My guide data provider (Schedules Direct) seems to have unreliable air dates so I changed to use start time instead.  Also, I commented out the "library" as it seems to be redundant - it appears to be used to detect duplicate symlinks, but that happens anyway. Additionally, it seemed the continue on line 85 (master) caused adding a symlink to be skipped for valid recordings to be added, so that is removed in this branch.
